### PR TITLE
Add a new priority and route to corresponding class

### DIFF
--- a/src/Priority.java
+++ b/src/Priority.java
@@ -1,5 +1,5 @@
 package src;
 
 public enum Priority {
-    LOW,MID,HIGH;
+    LOW, MID, HIGH, CRITICAL;
 }

--- a/src/TicketManager.java
+++ b/src/TicketManager.java
@@ -1,11 +1,9 @@
 package src;
 
-import src.teams.HighPriorityTeam;
-import src.teams.LowPriorityTeam;
-import src.teams.MidPriorityTeam;
-import src.teams.Team;
+import src.teams.*;
 
 public class TicketManager {
+    private int mId = 1;
     public static void main(String... args) {
         TicketManager manager = new TicketManager();
 
@@ -13,7 +11,7 @@ public class TicketManager {
         Ticket ticket = manager.createTicket();
 
         // Assign priority
-        ticket.setPriority(Priority.LOW);
+        ticket.setPriority(Priority.CRITICAL);
 
         // Route the ticket handling
         Team team = manager.getTeam(ticket.getPriority());
@@ -21,7 +19,7 @@ public class TicketManager {
     }
 
     private Ticket createTicket() {
-        Ticket ticket = new Ticket(1);
+        Ticket ticket = new Ticket(mId++);
         return ticket;
     }
 
@@ -31,8 +29,10 @@ public class TicketManager {
             team = new LowPriorityTeam();
         } else if (priority == Priority.MID) {
             team = new MidPriorityTeam();
-        } else {
+        } else if(priority == Priority.HIGH) {
             team = new HighPriorityTeam();
+        } else {
+            team = new CriticalPriorityTeam();
         }
         return team;
     }

--- a/src/teams/CriticalPriorityTeam.java
+++ b/src/teams/CriticalPriorityTeam.java
@@ -1,0 +1,10 @@
+package src.teams;
+
+import src.Ticket;
+
+public class CriticalPriorityTeam extends Team{
+    @Override
+    public void handleTicket(Ticket ticket) {
+        System.out.println("The Ticket is being handled by CriticalPriority Team");
+    }
+}


### PR DESCRIPTION
Problem with the change.

1. **Violation of Open-Closed Principle**
**Problem**: Every time you add a new priority level, you must modify existing code in getTeam().
```
if (priority == Priority.CRITICAL) {
    team = new CriticalPriorityTeam();
}
```
  **Why it's bad**: Code should be open for extension, but closed for modification. You’re constantly editing getTeam() for new priorities.

2. **Tight Coupling**
**Problem**: TicketManager depends directly on concrete team classes (LowPriorityTeam, MidPriorityTeam, HighPriorityTeam, etc.)

**Why it's bad:** You can’t swap, mock, or test routing logic without instantiating real team classes.

3. **Scalability Issues**
**Problem**: If you have 10+ priorities or need to route based on multiple rules (SLA, severity, region, etc.), the getTeam() logic becomes a giant mess.

```
if (priority == Priority.LOW && region == "Asia" && ... ) {
    // 🤯
}
```
**Why it's bad**: getTeam() becomes a God method with too many ifs. Hard to test, read, or change.

4. **Lack of Reusability / Extensibility**
**Problem**: You can’t plug in new routing logic (e.g. business hours, escalation paths) without rewriting getTeam().

**Why it's bad**: Real-world systems need flexible routing (dynamic rules, config-driven, etc.)

5. **Duplication and Violation of Single Responsibility**
**Problem**: TicketManager is doing both ticket creation and routing logic.

**Why it's bad**: This violates SRP (Single Responsibility Principle). It should delegate routing logic.