### PR TITLE
Ticket Lifecycle management

### DIFF
--- a/src/Ticket.java
+++ b/src/Ticket.java
@@ -4,13 +4,21 @@ public class Ticket {
     private final int mId;
     private Priority mPriority;
     private String mDescription;
+    private TicketState mState;
 
     Ticket(int id) {
         mId = id;
+        mState = TicketState.OPEN;
+        System.out.println("The ticket is created successfully and the state is: " + mState);
+    }
+    
+    public void setTicketState(TicketState state) {
+        mState = state;
+        System.out.println("The ticket state has been changed to "+ mState);
     }
 
     public void setDescription(String description) {
-        mDescription = mDescription;
+        mDescription = description;
     }
 
     public void setPriority(Priority priority) {
@@ -19,5 +27,9 @@ public class Ticket {
 
     public Priority getPriority() {
         return mPriority;
+    }
+
+    public TicketState getState() {
+        return mState;
     }
 }

--- a/src/TicketManager.java
+++ b/src/TicketManager.java
@@ -16,6 +16,7 @@ public class TicketManager {
         // Route the ticket handling
         Team team = manager.getTeam(ticket.getPriority());
         team.handleTicket(ticket);
+        ticket.setTicketState(TicketState.CLOSED);
     }
 
     private Ticket createTicket() {

--- a/src/TicketState.java
+++ b/src/TicketState.java
@@ -1,0 +1,5 @@
+package src;
+
+public enum TicketState {
+    OPEN,IN_PROGRESS,RESOLVED,CLOSED
+}

--- a/src/teams/CriticalPriorityTeam.java
+++ b/src/teams/CriticalPriorityTeam.java
@@ -1,10 +1,13 @@
 package src.teams;
 
 import src.Ticket;
+import src.TicketState;
 
 public class CriticalPriorityTeam extends Team{
     @Override
     public void handleTicket(Ticket ticket) {
+        ticket.setTicketState(TicketState.IN_PROGRESS);
         System.out.println("The Ticket is being handled by CriticalPriority Team");
+        ticket.setTicketState(TicketState.RESOLVED);
     }
 }


### PR DESCRIPTION
The problem here is: 

1. **Anyone Can Set Any State — No Validation**
Right now, any class can call:

`ticket.setTicketState(TicketState.CLOSED);`

...even if the current state is OPEN. That breaks lifecycle rules.

❌ No enforcement of valid state transitions
❌ No rules like: “Can’t go from OPEN → CLOSED directly”
❌ Any team or client can misuse the API

2. **Transition Logic is Duplicated**
Imagine multiple teams doing this:

```
ticket.setTicketState(IN_PROGRESS);
ticket.setTicketState(RESOLVED);
```

You’ll duplicate lifecycle logic in every handler (LowPriorityTeam, HighPriorityTeam, etc.)