### PR TITLE
Adding notification on ticket state change

### DIFF
--- a/src/Ticket.java
+++ b/src/Ticket.java
@@ -1,5 +1,9 @@
 package src;
 
+import src.notification.Email;
+import src.notification.NotificationMode;
+import src.notification.Slack;
+
 public class Ticket {
     private final int mId;
     private Priority mPriority;
@@ -15,6 +19,15 @@ public class Ticket {
     public void setTicketState(TicketState state) {
         mState = state;
         System.out.println("The ticket state has been changed to "+ mState);
+        notifyStateUpdate();
+    }
+
+    private void notifyStateUpdate() {
+        NotificationMode email = new Email();
+        NotificationMode slack = new Slack();
+
+        email.onTicketStateUpdated(mState);
+        slack.onTicketStateUpdated(mState);
     }
 
     public void setDescription(String description) {

--- a/src/notification/Email.java
+++ b/src/notification/Email.java
@@ -1,0 +1,10 @@
+package src.notification;
+
+import src.TicketState;
+
+public class Email extends NotificationMode{
+    @Override
+    public void onTicketStateUpdated(TicketState state) {
+        System.out.println("You have received a mail saying the state of ticket is updated to: "+ state);
+    }
+}

--- a/src/notification/NotificationMode.java
+++ b/src/notification/NotificationMode.java
@@ -1,0 +1,7 @@
+package src.notification;
+
+import src.TicketState;
+
+public abstract class NotificationMode {
+    public abstract void onTicketStateUpdated(TicketState state);
+}

--- a/src/notification/Slack.java
+++ b/src/notification/Slack.java
@@ -1,0 +1,11 @@
+package src.notification;
+
+import src.TicketState;
+
+public class Slack extends NotificationMode {
+
+    @Override
+    public void onTicketStateUpdated(TicketState state) {
+        System.out.println("You have received a slack message saying the state of ticket is updated to: "+ state);
+    }
+}


### PR DESCRIPTION
The problem here is

**1. Tight Coupling**'
- Ticket knows all notification types (Email, Slack, SMS, etc.).
- Every time a new one is added, you modify Ticket, violating the Open/Closed Principle.

`NotificationMode sms = new SMS();` // Add this? You must change Ticket code!

**2. Poor Extensibility**
- Imagine a plugin system or external teams adding a new notification channel — they'd have to touch the Ticket class.
- You can’t add or remove subscribers dynamically.

**3. Lack of Reusability**
- The notification mechanism is tied to Ticket.
- You can't reuse it across other domain models (e.g. Order, Bug, etc.).